### PR TITLE
feat: atomic monotonic nonce path for send_action/sign_action

### DIFF
--- a/src/actions/serialization.rs
+++ b/src/actions/serialization.rs
@@ -663,6 +663,27 @@ mod tests {
         assert_eq!(got.as_slice(), EXPECTED);
     }
 
+    /// Hardening: wider integers must pick the same minimal msgpack width as the
+    /// Python SDK. asset=300 -> uint16 (cd 01 2c), leverage=200 -> uint8 (cc c8).
+    /// The reference above only uses single-byte fixints, so this guards the
+    /// uint8/uint16 paths where rmp-serde and Python could otherwise disagree.
+    /// Generated via CPython `msgpack.packb` on the official SDK action shape.
+    #[test]
+    fn l1_flat_update_leverage_wide_ints_msgpack_matches_python_reference() {
+        use crate::actions::l1_actions::UpdateLeverage;
+
+        let action = UpdateLeverage::cross(300, 200);
+        let wrapper = super::L1ActionWrapper { action: &action };
+        let got = rmp_serde::to_vec_named(&wrapper).unwrap();
+        const EXPECTED: &[u8] = &[
+            0x84, 0xa4, 0x74, 0x79, 0x70, 0x65, 0xae, 0x75, 0x70, 0x64, 0x61, 0x74, 0x65, 0x4c, 0x65,
+            0x76, 0x65, 0x72, 0x61, 0x67, 0x65, 0xa5, 0x61, 0x73, 0x73, 0x65, 0x74, 0xcd, 0x01, 0x2c,
+            0xa7, 0x69, 0x73, 0x43, 0x72, 0x6f, 0x73, 0x73, 0xc3, 0xa8, 0x6c, 0x65, 0x76, 0x65, 0x72,
+            0x61, 0x67, 0x65, 0xcc, 0xc8,
+        ];
+        assert_eq!(got.as_slice(), EXPECTED);
+    }
+
     #[test]
     fn test_signed_action_kind_deserializes_user_signed_action() {
         let dest = Address::repeat_byte(0xAB);

--- a/src/clients/exchange/client.rs
+++ b/src/clients/exchange/client.rs
@@ -5,6 +5,9 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use reqwest::Client;
 use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     actions::{Action, SignedAction},
@@ -64,6 +67,7 @@ pub struct ExchangeClient {
     vault_address: Option<Address>,
     expires_after: Option<u64>,
     signer_private_key: Option<PrivateKeySigner>,
+    nonce_counter: Arc<AtomicU64>,
 }
 
 impl ExchangeClient {
@@ -79,6 +83,7 @@ impl ExchangeClient {
             vault_address: None,
             expires_after: None,
             signer_private_key: None,
+            nonce_counter: Arc::new(AtomicU64::new(Self::current_timestamp_ms())),
         }
     }
 
@@ -110,7 +115,7 @@ impl ExchangeClient {
         action: A,
         wallet: &PrivateKeySigner,
     ) -> Result<SignedAction<A>, Error> {
-        self.prepare_action(action)?.sign(wallet)
+        self.prepare_action(self.ensure_action_nonce(action))?.sign(wallet)
     }
 
     pub async fn send_signed_action<A: Action + Serialize>(
@@ -128,9 +133,44 @@ impl ExchangeClient {
         &self,
         action: A,
     ) -> Result<ExchangeResponse, Error> {
-        let prepared = self.prepare_action(action)?;
+        let prepared = self.prepare_action(self.ensure_action_nonce(action))?;
         let signer = self.signer_private_key.as_ref().ok_or(Error::SignerNotSet)?;
         let signed = prepared.sign(signer)?;
         self.send_signed_action(signed).await
+    }
+
+    /// Ensure the action carries a nonce before signing. If the caller already
+    /// set one, respect it; otherwise assign a strictly-monotonic nonce so
+    /// rapid-fire actions (e.g. UpdateLeverage then an order) never collide.
+    fn ensure_action_nonce<A: Action>(&self, action: A) -> A {
+        if action.nonce().is_some() {
+            action
+        } else {
+            action.with_nonce(self.next_nonce())
+        }
+    }
+
+    /// Monotonic nonce: current ms, bumped by 1 if we'd otherwise repeat or go
+    /// backwards within the same millisecond. Lock-free via a CAS loop.
+    fn next_nonce(&self) -> u64 {
+        let now = Self::current_timestamp_ms();
+        loop {
+            let last = self.nonce_counter.load(Ordering::Relaxed);
+            let next = if now > last { now } else { last + 1 };
+            if self
+                .nonce_counter
+                .compare_exchange(last, next, Ordering::SeqCst, Ordering::Relaxed)
+                .is_ok()
+            {
+                return next;
+            }
+        }
+    }
+
+    fn current_timestamp_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
     }
 }


### PR DESCRIPTION
## Summary

Two commits the fork has been running, offered back upstream:

1. **`feat:` atomic monotonic nonce path** — `send_action` / `sign_action` now ensure every action carries a nonce before signing. A caller-set nonce is respected; otherwise a strictly-monotonic nonce is assigned via a lock-free CAS counter (current ms, bumped by 1 on collision). This prevents nonce reuse when firing rapid sequential actions (e.g. `UpdateLeverage` immediately followed by an order). Upstream's safer `ok_or(Error::SignerNotSet)` signer handling is preserved.

2. **`test:` wider-int msgpack vector** — the existing `l1_flat_update_leverage_msgpack_matches_python_reference` only exercises single-byte fixints. This adds a vector (`asset=300` → `uint16`, `leverage=200` → `uint8`) verified against CPython `msgpack.packb`, guarding the `uint8`/`uint16` width paths against any rmp-serde vs Python divergence in the L1 signing hash.

## Testing

- `cargo test --lib` → 23 passing (22 existing + 1 new vector)
- `cargo check --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)