### PR TITLE
fix(ws): omit null dex in AllMids/ClearinghouseState subscriptions

### DIFF
--- a/src/clients/ws/subscription.rs
+++ b/src/clients/ws/subscription.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum Subscription {
     #[serde(rename = "allMids")]
-    AllMids { dex: Option<String> },
+    AllMids {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dex: Option<String>,
+    },
 
     Notification { user: String },
 
@@ -24,7 +27,11 @@ pub enum Subscription {
     },
 
     #[serde(rename = "clearinghouseState")]
-    ClearinghouseState { user: String, dex: Option<String> },
+    ClearinghouseState {
+        user: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dex: Option<String>,
+    },
 
     #[serde(rename = "openOrders")]
     OpenOrders { user: String, dex: Option<String> },


### PR DESCRIPTION
Hyperliquid rejects subscriptions that serialize "dex":null. Add skip_serializing_if so the field is dropped when None. 